### PR TITLE
add metadata to all pages

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,4 +1,9 @@
 import Link from "next/link";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Page not found",
+};
 
 export default function NotFound() {
   return (

--- a/app/posts/[postId]/not-found.tsx
+++ b/app/posts/[postId]/not-found.tsx
@@ -1,9 +1,4 @@
 import Link from "next/link";
-import { Metadata } from "next";
-
-export const metadata: Metadata = {
-  title: "Post not found",
-};
 
 export default function NotFound() {
   return (

--- a/app/posts/[postId]/not-found.tsx
+++ b/app/posts/[postId]/not-found.tsx
@@ -1,4 +1,9 @@
 import Link from "next/link";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Post not found",
+};
 
 export default function NotFound() {
   return (

--- a/app/posts/[postId]/page.tsx
+++ b/app/posts/[postId]/page.tsx
@@ -17,7 +17,7 @@ export async function generateMetadata({
 }: PostParams): Promise<Metadata> {
   const posts = getLatestPosts();
   const currPost = posts.find((post) => post.id === postId);
-  if (!currPost) return { title: "Post Not Found" };
+  if (!currPost) return { title: "Post not found" };
   return { title: currPost.title };
 }
 

--- a/app/posts/page.tsx
+++ b/app/posts/page.tsx
@@ -1,5 +1,10 @@
 import getLatestPosts from "@/helpers/getLatestPosts";
 import PostCard from "../components/PostCard";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "All posts",
+};
 
 export default function Posts() {
   const posts = getLatestPosts();


### PR DESCRIPTION
I couldn't export a metadata object from a page called `not-found.tsx`.

I was only able to generate metadata dynamically using `generateMetadata()` function in /posts/[postId] to show `Post not found` message when a post doesn't exist because there I had the ability to see if a post exists or not.